### PR TITLE
docs(examples): add better examples

### DIFF
--- a/docs/data-sources/error.md
+++ b/docs/data-sources/error.md
@@ -18,8 +18,8 @@ variable "two" {}
 
 data "validation_error" "err" {
   condition = var.one == var.two
-  summary = "var.one and var.two must never be equal"
-  details = <<EOF
+  summary   = "var.one and var.two must never be equal"
+  details   = <<EOF
 When var.one and var.two are equal, bad things can happen.
 Please use differing values for these inputs.
 var.one: ${var.one}

--- a/docs/data-sources/warning.md
+++ b/docs/data-sources/warning.md
@@ -18,10 +18,10 @@ variable "two" {}
 
 data "validation_warning" "warn" {
   condition = var.one == var.two
-  summary = "var.one and var.two are equal. This will cause an error in future versions"
-  details = <<EOF
-In a future release of this code, var.one and var.two may no longer be equal. Please consider modifying the values to
-be distinct to avoid execution failures.
+  summary   = "var.one and var.two are equal. This will cause an error in future versions"
+  details   = <<EOF
+In a future release of this code, var.one and var.two may no longer be equal. 
+Please consider modifying the values to avoid execution failures.
 var.one: ${var.one}
 var.two: ${var.two}
 EOF

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,10 @@ The Validation provider allows users to validate multiple variables in the same 
 This is a logical provider, which means that it works entirely within Terraform's logic, and doesn't interact with any
 other services.
 
+This provider requires no configuration.
+
+```hcl
+provider "validation" {}
+```
+
 For information on the specific resources available, see the links in the navigation bar.

--- a/docs/resources/error.md
+++ b/docs/resources/error.md
@@ -18,8 +18,8 @@ variable "two" {}
 
 resource "validation_error" "error" {
   condition = var.one == var.two
-  summary = "var.one and var.two must never be equal"
-  details = <<EOF
+  summary   = "var.one and var.two must never be equal"
+  details   = <<EOF
 When var.one and var.two are equal, bad things can happen.
 Please use differing values for these inputs.
 var.one: ${var.one}

--- a/docs/resources/warning.md
+++ b/docs/resources/warning.md
@@ -18,10 +18,10 @@ variable "two" {}
 
 resource "validation_warning" "warn" {
   condition = var.one == var.two
-  summary = "var.one and var.two are equal. This will cause an error in future versions"
-  details = <<EOF
-In a future release of this code, var.one and var.two may no longer be equal. Please consider modifying the values to
-be distinct to avoid execution failures.
+  summary   = "var.one and var.two are equal. This will cause an error in future versions"
+  details   = <<EOF
+In a future release of this code, var.one and var.two may no longer be equal. 
+Please consider modifying the values to avoid execution failures.
 var.one: ${var.one}
 var.two: ${var.two}
 EOF

--- a/examples/data-sources/validation_error/data-source.tf
+++ b/examples/data-sources/validation_error/data-source.tf
@@ -3,8 +3,8 @@ variable "two" {}
 
 data "validation_error" "err" {
   condition = var.one == var.two
-  summary = "var.one and var.two must never be equal"
-  details = <<EOF
+  summary   = "var.one and var.two must never be equal"
+  details   = <<EOF
 When var.one and var.two are equal, bad things can happen.
 Please use differing values for these inputs.
 var.one: ${var.one}

--- a/examples/data-sources/validation_warning/data-source.tf
+++ b/examples/data-sources/validation_warning/data-source.tf
@@ -3,10 +3,10 @@ variable "two" {}
 
 data "validation_warning" "warn" {
   condition = var.one == var.two
-  summary = "var.one and var.two are equal. This will cause an error in future versions"
-  details = <<EOF
-In a future release of this code, var.one and var.two may no longer be equal. Please consider modifying the values to
-be distinct to avoid execution failures.
+  summary   = "var.one and var.two are equal. This will cause an error in future versions"
+  details   = <<EOF
+In a future release of this code, var.one and var.two may no longer be equal. 
+Please consider modifying the values to avoid execution failures.
 var.one: ${var.one}
 var.two: ${var.two}
 EOF

--- a/examples/resources/validation_error/resource.tf
+++ b/examples/resources/validation_error/resource.tf
@@ -3,8 +3,8 @@ variable "two" {}
 
 resource "validation_error" "error" {
   condition = var.one == var.two
-  summary = "var.one and var.two must never be equal"
-  details = <<EOF
+  summary   = "var.one and var.two must never be equal"
+  details   = <<EOF
 When var.one and var.two are equal, bad things can happen.
 Please use differing values for these inputs.
 var.one: ${var.one}

--- a/examples/resources/validation_warning/resource.tf
+++ b/examples/resources/validation_warning/resource.tf
@@ -3,10 +3,10 @@ variable "two" {}
 
 resource "validation_warning" "warn" {
   condition = var.one == var.two
-  summary = "var.one and var.two are equal. This will cause an error in future versions"
-  details = <<EOF
-In a future release of this code, var.one and var.two may no longer be equal. Please consider modifying the values to
-be distinct to avoid execution failures.
+  summary   = "var.one and var.two are equal. This will cause an error in future versions"
+  details   = <<EOF
+In a future release of this code, var.one and var.two may no longer be equal. 
+Please consider modifying the values to avoid execution failures.
 var.one: ${var.one}
 var.two: ${var.two}
 EOF

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,6 +11,12 @@ The Validation provider allows users to validate multiple variables in the same 
 This is a logical provider, which means that it works entirely within Terraform's logic, and doesn't interact with any
 other services.
 
+This provider requires no configuration.
+
+```hcl
+provider "validation" {}
+```
+
 For information on the specific resources available, see the links in the navigation bar.
 
 {{- /* No schema in this provider, so no need for this: .SchemaMarkdown | trimspace */ -}}


### PR DESCRIPTION
Adds better examples to the Terraform documentation rendered on the provider page.