### PR TITLE
refactor(blocks): make schema reusable

### DIFF
--- a/docs/data-sources/warning.md
+++ b/docs/data-sources/warning.md
@@ -33,7 +33,7 @@ EOF
 
 ### Required
 
-- `condition` (Boolean) The condition which, if true, causes an error to be thrown.
+- `condition` (Boolean) The condition which, if true, causes a warning message to be printed.
 - `summary` (String) The message displayed to the user if the condition is true.
 
 ### Optional

--- a/validation/data_source_error.go
+++ b/validation/data_source_error.go
@@ -7,19 +7,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var errorDataSchema = map[string]*schema.Schema{
+	conditionKey: {
+		Description: errorConditionDescription,
+		Type:        schema.TypeBool,
+		Required:    true,
+	},
+	summaryKey: summarySchema,
+	detailsKey: detailsSchema,
+}
+
 func dataSourceError() *schema.Resource {
 	return &schema.Resource{
 		Description: "Causes an error to be thrown if condition is true.",
 		ReadContext: dataSourceErrorRead,
-		Schema: map[string]*schema.Schema{
-			conditionKey: {
-				Description: errorConditionDescription,
-				Type:        schema.TypeBool,
-				Required:    true,
-			},
-			summaryKey: summarySchema,
-			detailsKey: detailsSchema,
-		},
+		Schema:      errorDataSchema,
 	}
 }
 

--- a/validation/data_source_warning.go
+++ b/validation/data_source_warning.go
@@ -7,19 +7,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// TODO: Refactor into a function that returns the schema
+var warnDataSchema = map[string]*schema.Schema{
+	conditionKey: {
+		Description: warnConditionDescription,
+		Type:        schema.TypeBool,
+		Required:    true,
+	},
+	summaryKey: summarySchema,
+	detailsKey: detailsSchema,
+}
+
 func dataSourceWarning() *schema.Resource {
 	return &schema.Resource{
 		Description: "Causes a warning message to be printed if condition is true.",
 		ReadContext: dataSourceWarningRead,
-		Schema: map[string]*schema.Schema{
-			conditionKey: {
-				Description: errorConditionDescription,
-				Type:        schema.TypeBool,
-				Required:    true,
-			},
-			summaryKey: summarySchema,
-			detailsKey: detailsSchema,
-		},
+		Schema:      warnDataSchema,
 	}
 }
 

--- a/validation/resource_error.go
+++ b/validation/resource_error.go
@@ -14,6 +14,17 @@ const (
 	detailsDescription        = "More details about the message being displayed to the user, if any."
 )
 
+var errorResourceSchema = map[string]*schema.Schema{
+	conditionKey: {
+		Type:        schema.TypeBool,
+		Required:    true,
+		Description: errorConditionDescription,
+		ForceNew:    true,
+	},
+	summaryKey: summarySchema,
+	detailsKey: detailsSchema,
+}
+
 func resourceError() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Causes an error to be thrown during execution if the condition is true.",
@@ -21,17 +32,7 @@ func resourceError() *schema.Resource {
 		ReadContext:   resourceErrorRead,
 		UpdateContext: resourceErrorUpdate,
 		DeleteContext: resourceErrorDelete,
-
-		Schema: map[string]*schema.Schema{
-			conditionKey: {
-				Type:        schema.TypeBool,
-				Required:    true,
-				Description: errorConditionDescription,
-				ForceNew:    true,
-			},
-			summaryKey: summarySchema,
-			detailsKey: detailsSchema,
-		},
+		Schema:        errorResourceSchema,
 	}
 }
 

--- a/validation/resource_warning.go
+++ b/validation/resource_warning.go
@@ -12,6 +12,17 @@ const (
 	warnConditionDescription = "The condition which, if true, causes a warning message to be printed."
 )
 
+var warnResourceSchema = map[string]*schema.Schema{
+	conditionKey: {
+		Type:        schema.TypeBool,
+		Required:    true,
+		Description: warnConditionDescription,
+		ForceNew:    true,
+	},
+	summaryKey: summarySchema,
+	detailsKey: detailsSchema,
+}
+
 func resourceWarning() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Causes a warning to be printed if the condition is true.",
@@ -19,17 +30,7 @@ func resourceWarning() *schema.Resource {
 		ReadContext:   resourceWarningRead,
 		UpdateContext: resourceWarningUpdate,
 		DeleteContext: resourceWarningDelete,
-
-		Schema: map[string]*schema.Schema{
-			conditionKey: {
-				Type:        schema.TypeBool,
-				Required:    true,
-				Description: warnConditionDescription,
-				ForceNew:    true,
-			},
-			summaryKey: summarySchema,
-			detailsKey: detailsSchema,
-		},
+		Schema:        warnResourceSchema,
 	}
 }
 


### PR DESCRIPTION
Makes the error and warning schema reusable across resources and data sources to better support multiple validation blocks in the future.

See #1 